### PR TITLE
Fixed errant file reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = function (sails) {
                         return next(err);
                     }
 
-                    sails.log.info('User hook controllers loaded from ' + dir.models + '.');
+                    sails.log.info('User hook controllers loaded from ' + dir.controllers + '.');
 
                     return next(null);
                 });


### PR DESCRIPTION
When you load controllers you say you are loading them from the models folder, just replaced the folder we are referencing.
