### PR TITLE
Models injection via sails.hook.orm.models

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = function (sails) {
                         return next(err);
                     }
 
-                    sails.log.info('User hook controllers loaded from ' + dir.models + '.');
+                    sails.log.info('User hook controllers loaded from ' + dir.controllers + '.');
 
                     return next(null);
                 });

--- a/libs/models.js
+++ b/libs/models.js
@@ -27,6 +27,7 @@ module.exports = function (sails, dir, cb) {
             }
 
             var finalModels = sails.util.merge(models, supplements);
+            sails.hooks.orm.models = sails.util.merge(finalModels || {}, sails.hooks.orm.models || {});
             sails.models = sails.util.merge(finalModels || {}, sails.models || {});
 
             cb();


### PR DESCRIPTION
- Models injection now use sails.hook.orm.models -- fixes bug with models injections #9 #10 
- Fixed small typo in controllers injection
